### PR TITLE
Updates for GEOS-Chem 14.3.0

### DIFF
--- a/IDL/README.md
+++ b/IDL/README.md
@@ -1,0 +1,44 @@
+# IDL scripts for creating benchmark plots
+
+This repository contains the IDL scripts for creating plots from the
+1-year benchmark simulations. 
+
+## Instructions
+
+1. For each new benchmark, add a new input file `input/GC_X.Y.Z-rc.N.1yr`, where `X.Y.Z` is the version number and `N` is the release candidate number.  Edit the settings in the file as follows:
+   
+```console
+##### Parameters for 1st model #####
+V1: GCC_X.Y.Z                           # version number of Ref model
+D1: /path/to/Ref/model/run-directory/OutputDir/
+L1: GEOSChem.SpeciesConc.2019
+M1: MERRA2
+R1: 4
+Y1: 2019
+
+##### Parameters for 2nd model #####
+V2: GCC_X.Y.Z                           # version number of Dev model
+D2: /path/to/Dev/model/run-directory/OutputDir/
+L2: GEOSChem.SpeciesConc.2019
+M2: MERRA2
+R2: 4
+Y2: 2019
+```
+   
+2. Use these commands to generate the plots.  (NOTE: PDF output is now always turned on, so there is no need to manually set `/DO_PDF`.)
+   
+```console
+$ benchmark_1yr, 'input/GC_X.Y.Z-rc.N.1yr', /DO_Ox
+$ benchmark_1yr, 'input/GC_X.Y.Z-rc.N.1yr', /DO_CO
+$ benchmark_1yr, 'input/GC_X.Y.Z-rc.N.1yr', /DO_MOZAIC
+$ benchmark_1yr, 'input/GC_X.Y.Z-rc.N.1yr', /DO_AIRCAFT
+$ benchmark_1yr, 'input/GC_X.Y.Z-rc.N.1yr', /DO_PAN
+$ benchmark_1yr, 'input/GC_X.Y.Z-rc.N.1yr', /DO_AEROSOL
+```
+
+3. Run the `move_output.sh` script, which will move the files to the `ModelVsObs` subdirectory of the benchmark plots folder that you specify:
+
+```console
+$ cd output
+$ ./move_output.sh /path/to/benchmark/results/folder
+```

--- a/IDL/benchmark_1yr.pro
+++ b/IDL/benchmark_1yr.pro
@@ -294,11 +294,15 @@ pro BenchMark_1yr, InputFile,                                                $
    Do_Cloud_Diffs = Keyword_Set( Do_Cloud_Diffs )
    Do_BrO         = Keyword_Set( Do_BrO         )
    Do_PAN         = Keyword_Set( Do_PAN         )
-   Do_PDF         = Keyword_Set( Do_PDF         )
+   ;---------------------------------------------------------------
+   ; Now always save output as PDF (Bob Yantosca, 29 Jan 2024)
+   ;Do_PDF         = Keyword_Set( Do_PDF         )
+   Do_PDF         = 1
+   ;---------------------------------------------------------------
    Do_GCHP        = Keyword_Set( Do_GCHP        )
    Do_STE         = Keyword_Set( Do_STE         )
    DynRange       = Keyword_Set( DynRange       )
-
+   
    ; Define suffix for plots
    if ( DynRange )                    $
       then PsSuffix = '.dyn_range.ps' $

--- a/IDL/input/GC_14.3.0-rc.0.1yr
+++ b/IDL/input/GC_14.3.0-rc.0.1yr
@@ -1,0 +1,28 @@
+###############################################################################
+#####         INPUT FILE FOR 1-YEAR BENCHMARK PLOTTING PROGRAMS           #####
+#####    Define dirs, model names, and other relevant quantities here     #####
+#####                                                                     #####
+##### V[1/2] = Version Number                                             #####
+##### D[1/2] = Directory with files                                       #####
+##### L[1/2] = Label used to identify netCDF file names                   #####
+##### M[1/2] = Model name                                                 #####
+##### R[1/2] = Model resolution                                           #####
+##### Y[1/2] = Year of simulation                                         #####
+###############################################################################
+
+##### Parameters for 1st model #####
+V1: GCC_14.2.0
+D1: /n/holyscratch01/jacob_lab/ryantosca/BM/1yr/14.2.0-rc.2/GCClassic/FullChem/OutputDir/
+L1: GEOSChem.SpeciesConc.2019
+M1: MERRA2
+R1: 4
+Y1: 2019
+
+##### Parameters for 2nd model #####
+V2: GCC_14.3.0
+D2: /n/holyscratch01/jacob_lab/ryantosca/BM/1yr/14.3.0-rc.0/GCClassic/FullChem/OutputDir/
+L2: GEOSChem.SpeciesConc.2019
+M2: MERRA2
+R2: 4
+Y2: 2019
+

--- a/IDL/subroutines/all_stations_cmdl_geos.pro
+++ b/IDL/subroutines/all_stations_cmdl_geos.pro
@@ -19,7 +19,7 @@ pro all_stations_cmdl_geos, species1, species, max_sta, pref_spc,  pref_p, year,
    Type1 = CTM_Type( Model, Res=[ DLon, DLat ] )
 
    ; Read data
-   filest  = 'data/netCDF/Sites.ground.CO.1'
+   filest = '/n/jacob_lab/Lab/obs_data_for_bmk/data_for_idl_code/netCDF/Sites.ground.CO.1'
 
    ;PRINT, filest
    openr, usta, filest, /get_lun


### PR DESCRIPTION
The following updates were added for GEOS-Chem 14.3.0:
1. Added new input file `input/GC_14.3.0-rc.0.1y4`
2. Now read large data files from `/n/jacob_lab/Lab/obs_data_for_bmk/data_for_idl_code/` directory tree
3. Hardcode `DO_PDF=1` in `IDL/benchmark_1yr.pro`
4. Added `IDL/README.md` with instructions on how to create benchmark plots